### PR TITLE
fix: find_section_boundries()

### DIFF
--- a/src/analyze.rs
+++ b/src/analyze.rs
@@ -900,7 +900,7 @@ pub fn plot_to_file(collection: AWRSCollection, fname: String, args: Args) {
         // Print calculations:
         
         make_notes!(&logfile_name, args.quiet, "\t\tMarked as TOP in {:.2}% of probes\n",  (x_n.len() as f64 / x_vals.len() as f64 )* 100.0);
-        make_notes!(&logfile_name, args.quiet, "{: >43}  {: <16.2} \tSTDDEV PCT of DB Time: {:.2}%\n",   "--- AVG PCT of DB Time (%):", &avg_exec_t, &stddev_exec_t);
+        make_notes!(&logfile_name, args.quiet, "{: >43}%  {: <16.2} \tSTDDEV PCT of DB Time: {:.2}%\n",   "--- AVG PCT of DB Time (%):", &avg_exec_t, &stddev_exec_t);
         make_notes!(&logfile_name, args.quiet, "{: >38}  {: <16.2} \tSTDDEV Wait Time (s):  {:.2}\n",   "--- AVG Wait Time (s):",  &avg_exec_s, &stddev_exec_s);
         make_notes!(&logfile_name, args.quiet, "{: >40}{: <8.2}  \t\tSTDDEV No. executions: {:.2}\n",   "--- AVG No. executions: ", &avg_exec_n, &stddev_exec_n);
         make_notes!(&logfile_name, args.quiet, "{: >39} {: <16.2} \tSTDDEV wait/exec (ms): {:.2}\n\n", "--- AVG wait/exec (ms):", &avg_wait_per_exec_ms, &stddev_wait_per_exec_ms);


### PR DESCRIPTION
fix: find_section_boundries() - error handling added if sections are not found in a report file